### PR TITLE
feat: add insertBatchBlock! function to editor module

### DIFF
--- a/src/run/avelino/logseq_libs/editor.cljs
+++ b/src/run/avelino/logseq_libs/editor.cljs
@@ -21,6 +21,16 @@
        (j/call :insertBlock block-id content (clj->js opts))
        (.then #(js->clj % :keywordize-keys true)))))
 
+(defn insert-batch-block!
+  "Insert multiple blocks at once"
+  ([block-id batch-blocks]
+   (insert-batch-block! block-id batch-blocks nil))
+  ([block-id batch-blocks opts]
+   (-> ls/logseq
+       (j/get :Editor)
+       (j/call :insertBatchBlock block-id (clj->js batch-blocks) (clj->js opts))
+       (.then #(js->clj % :keywordize-keys true)))))
+
 (defn update-block!
   "Update block content"
   [block-id content]

--- a/test/__mocks__/@logseq/libs.js
+++ b/test/__mocks__/@logseq/libs.js
@@ -30,6 +30,7 @@ const Editor = {
     // Block operations
     removeBlock: () => Promise.resolve(),
     insertBlock: () => Promise.resolve(),
+    insertBatchBlock: (blockId, blocks, opts) => Promise.resolve(blocks),
     updateBlock: () => Promise.resolve(),
     getBlock: () => Promise.resolve({ uuid: 'block-123', content: 'test content' }),
 

--- a/test/run/avelino/logseq_libs/editor_test.cljs
+++ b/test/run/avelino/logseq_libs/editor_test.cljs
@@ -41,6 +41,28 @@
                             (is (= {:uuid "block-123" :content "content"} (js->clj result :keywordize-keys true)))
                             (done))))))))
 
+  (testing "insert-batch-block!"
+    (testing "with required params only"
+      (async done
+             (let [batch-blocks [{:content "block 1"} {:content "block 2"}]]
+               (with-redefs [ls/logseq #js {:Editor #js {:insertBatchBlock (fn [_ blocks _]
+                                                                             (js/Promise.resolve (clj->js blocks)))}}]
+                 (-> (editor/insert-batch-block! "block-123" batch-blocks)
+                     (.then (fn [result]
+                              (is (= batch-blocks result))
+                              (done))))))))
+
+    (testing "with optional params"
+      (async done
+             (let [batch-blocks [{:content "block 1"} {:content "block 2"}]
+                   opts {:before true}]
+               (with-redefs [ls/logseq #js {:Editor #js {:insertBatchBlock (fn [_ blocks options]
+                                                                             (js/Promise.resolve (clj->js {:blocks blocks :options options})))}}]
+                 (-> (editor/insert-batch-block! "block-123" batch-blocks opts)
+                     (.then (fn [result]
+                              (is (= {:blocks batch-blocks :options opts} result))
+                              (done)))))))))
+
   (testing "update-block!"
     (async done
            (with-redefs [ls/logseq mocks/logseq-mock]


### PR DESCRIPTION
This commit adds the `insert-batch-block!` function to the editor module, allowing for batch insertion of multiple blocks at once. The function accepts a block ID, a collection of blocks to insert, and optional parameters.

Key changes:
- Added `insert-batch-block!` function with support for both 2-arity and 3-arity calls
- Updated mock implementation in `@logseq/libs.js` to support batch block insertion
- Added comprehensive tests for the new function in `editor_test.cljs`

This feature enhances the library's capabilities for bulk block operations, making it more efficient to insert multiple blocks in a single operation.

fixed: #4